### PR TITLE
add test so students can't hard code turn count

### DIFF
--- a/spec/current_player_spec.rb
+++ b/spec/current_player_spec.rb
@@ -3,9 +3,11 @@ require_relative '../lib/current_player.rb'
 describe "./lib/current_player.rb" do
   describe '#turn_count' do
     it 'counts occupied positions' do
-      board = ["O", " ", " ", " ", "X", " ", " ", " ", "X"]
+      board1 = ["O", " ", " ", " ", "X", " ", " ", " ", "X"]
+      board2 = ["O", " ", " ", " ", "X", " ", " ", "O", "X"]
 
-      expect(turn_count(board)).to eq(3)
+      expect(turn_count(board1)).to eq(3)
+      expect(turn_count(board2)).to eq(4)
     end
   end
 


### PR DESCRIPTION
@curiositypaths 

I had a student today who was passing this test using a counter like this:

```
def turn_count(board)
  counter = 1
  board.each do |index|
    if index == ("X" || "O")
      counter += 1
    end
  end
  return counter
end
```

He'd come up with a reason about input_to_index meaning that he should start counting up at 1, but realized when we talked about it that it didn't make sense to start counting at 1 because turn count could then never be 0. I just added another expectation to that first test to make sure they're not hard coding the answer, by accident or on purpose!